### PR TITLE
Fix mcrypt version failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
-sudo: false
+sudo: true
 language: node_js
+
+# node v3+ requires C++11-compatible compiler. See https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements
+env:
+  - CXX=g++-4.8
 addons:
+  sources:
+    - ubuntu-toolchain-r-test
+  packages:
+    - g++-4.8
   apt_packages:
     - libmcrypt4
     - libmcrypt-dev
@@ -8,3 +16,5 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs-v2.5.0"
+  - "3"
+  - "4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,14 @@ language: node_js
 env:
   - CXX=g++-4.8
 addons:
-  sources:
-    - ubuntu-toolchain-r-test
-  packages:
-    - g++-4.8
-  apt_packages:
-    - libmcrypt4
-    - libmcrypt-dev
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+      - libmcrypt4
+      - libmcrypt-dev
+
 node_js:
   - "0.10"
   - "0.12"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "mcrypt": "0.0.15"
+    "mcrypt": "^0.1"
   },
   "devDependencies": {
     "chai": "^3.2.0",


### PR DESCRIPTION
Because this library uses fixed version of mcrypt that doesn't work on latest nodejs version e.g. >= 4 this will install latest stable mcrypt that fixed that  problems