### PR TITLE
Remove outdated mcrypt dependency and rely on native node crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
-      - libmcrypt4
-      - libmcrypt-dev
 
 node_js:
   - "0.10"
@@ -22,3 +20,7 @@ node_js:
   - "5"
   - "6"
   - "8"
+  - "10"
+  - "12"
+  - "14"
+  - "16"

--- a/README.md
+++ b/README.md
@@ -10,15 +10,8 @@ This code is based on the [PHP implementation of RNCryptor](https://github.com/R
 ## Important Recent Changes
 Now a `Buffer` is returned, use `.toString()` to convert the result to whatever format you need.
 
-## Install on Linux (Debian)
+## Install
 ```bash
-sudo apt-get install libmcrypt4 libmcrypt-dev
-npm install jscryptor
-```
-
-## Install on Mac OS X w/ Homebrew
-```bash
-brew install libmcrypt
 npm install jscryptor
 ```
 

--- a/lib/RNCryptor.js
+++ b/lib/RNCryptor.js
@@ -19,7 +19,6 @@
 
     switch(version) {
       case 3:
-        settings.mode = 'cbc';
         settings.options = 1;
         settings.hmac.includes_header = true;
         settings.hmac.algorithm = 'sha256';
@@ -108,11 +107,6 @@
     return crypto.createHmac(_settings.hmac.algorithm, hmac_key).update(hmac_message).digest();
   };
 
-  var _strip_pkcs7_padding = function(plain_text) {
-    var pad_length = plain_text.slice(-1).toString().charCodeAt();
-    return plain_text.slice(0, plain_text.length - pad_length);
-  };
-
   var _generate_initialized_components = function(version) {
     return {
       headers: {
@@ -146,12 +140,6 @@
     var hmac = _generate_hmac(components, hmac_key);
 
     return Buffer.concat([data, hmac]).toString('base64');
-  };
-
-  var _add_pkcs7_padding = function (plain_text, block_size) {
-    var pad_size = block_size - (plain_text.length % block_size);
-    var padding = new Buffer(new Array(pad_size + 1).join(String.fromCharCode(pad_size)), 'binary');
-    return Buffer.concat([plain_text, padding]);
   };
 
   var RNCryptor = {};

--- a/lib/RNCryptor.js
+++ b/lib/RNCryptor.js
@@ -1,12 +1,11 @@
 (function() {
   var crypto = require('crypto');
-  var MCrypt = require('mcrypt').MCrypt;
 
   var _settings = {};
 
   var _configure_settings = function(version) {
     var settings = {
-      algorithm: 'rijndael-128',
+      algorithm: 'aes-256-cbc',
       salt_length: 8,
       iv_length: 16,
       pbkdf2: {
@@ -128,17 +127,12 @@
   };
 
   var _generate_iv = function (block_size) {
-    var mcrypt = new MCrypt(_settings.algorithm, _settings.mode);
-    var iv = mcrypt.generateIv();
-
-    return iv.slice(0, block_size);
+    return crypto.randomBytes(block_size)
   };
 
   var _encrypt = function(plain_text, components, encryption_key, hmac_key) {
-    var padded_plain_text = _add_pkcs7_padding(plain_text, components.headers.iv.length);
-    var mcrypt = new MCrypt(_settings.algorithm, _settings.mode);
-    mcrypt.open(encryption_key, components.headers.iv);
-    components.cipher_text = mcrypt.encrypt(padded_plain_text);
+    const cipher = crypto.createCipheriv(_settings.algorithm, encryption_key, components.headers.iv)
+    components.cipher_text = Buffer.concat([cipher.update(plain_text), cipher.final()])
 
     var data = Buffer.concat([
       components.headers.version,
@@ -228,11 +222,8 @@
     }
 
     var key = _generate_key(password, components.headers.encryption_salt);
-    var mcrypt = new MCrypt(_settings.algorithm, _settings.mode);
-    mcrypt.open(key, components.headers.iv);
-
-    var padded_plain_text = mcrypt.decrypt(components.cipher_text);
-    return _strip_pkcs7_padding(padded_plain_text);
+    const decipher = crypto.createDecipheriv(_settings.algorithm, key, components.headers.iv)
+    return Buffer.concat([decipher.update(components.cipher_text), decipher.final()]).toString()
   };
 
   module.exports = RNCryptor;

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
   "name": "jscryptor",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Javascript implementation of RNCryptor",
   "main": "index.js",
   "scripts": {
     "test": "mocha"
-  },
-  "dependencies": {
-    "mcrypt": "^0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -28,5 +25,8 @@
   "bugs": {
     "url": "https://github.com/chesstrian/JSCryptor/issues"
   },
-  "homepage": "https://github.com/chesstrian/JSCryptor"
+  "homepage": "https://github.com/chesstrian/JSCryptor",
+  "dependencies": {
+    "mcrypt": "^0.1"
+  }
 }


### PR DESCRIPTION
As mcrypt is not maintained anymore node versions >= 12 can't use JSCryptor anymore.

Relying solely on node crypto might break backwards compatibility (not sure which versions will work).

- 'rijndael-128' is now 'aes-256-cbc'
- _settings.mode is unrequired
- _add_pkcs7_padding / _strip_pkcs7_padding are not necessary anymore, as node crypto's native functions createCipheriv / createDecipheriv do the job

TODO:
find out which node versions support native node crypto and if there are versions left behind decide whether they can be ditched